### PR TITLE
increase default number of fixed-k trials from 10 to 50

### DIFF
--- a/sky_area/run_sky_area.py
+++ b/sky_area/run_sky_area.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
 
     parser.add_option('--maxpts', type='int', help='maximum number of posterior points to use')
 
-    parser.add_option('--trials', type='int', default=10, help='maximum number of trials to build sky posterior [default: %default]')
+    parser.add_option('--trials', type='int', default=50, help='maximum number of trials to build sky posterior [default: %default]')
 
     parser.add_option('--noskyarea', action='store_true', default=False, help='turn off sky area computation')
 


### PR DESCRIPTION
Allowing for many more fixed-k trials produces much more consistent results, especially when many clusters are present.
