### PR TITLE
Compute conditional mean and standard deviation of distance exactly

### DIFF
--- a/bin/run_sky_area.py
+++ b/bin/run_sky_area.py
@@ -164,11 +164,7 @@ if __name__ == '__main__':
     fits_nest = True
 
     if not args.enable_distance_map:
-        fits.write_sky_map(os.path.join(args.outdir, 'skymap.fits.gz'),
-                           skypost.as_healpix(args.nside, nest=fits_nest), 
-                           creator=parser.get_prog_name(),
-                           objid=args.objid, gps_time=data['time'].mean(),
-                           nest=fits_nest)
+        hpmap = skypost.as_healpix(args.nside, nest=fits_nest)
     else:
         print('Constructing 3D clustered posterior.')
         skypost3d = sac.Clustered3DKDEPosterior(np.column_stack((data['ra'], data['dec'], data['dist'])))
@@ -177,9 +173,9 @@ if __name__ == '__main__':
         map3d = skypost3d.as_healpix(args.nside, nest=fits_nest)
         mapsky = skypost.as_healpix(args.nside, nest=fits_nest)
 
-        hpmap = np.column_stack((mapsky, map3d))
+        hpmap = np.column_stack((mapsky, map3d)).T
         
-        hp.write_map(os.path.join(args.outdir, 'skymap.fits.gz'),
-                     hpmap.T,
-                     nest=fits_nest)
-                         
+    fits.write_sky_map(os.path.join(args.outdir, 'skymap.fits.gz'),
+                       hpmap, creator=parser.get_prog_name(),
+                       objid=args.objid, gps_time=data['time'].mean(),
+                       nest=fits_nest)

--- a/bin/run_sky_area.py
+++ b/bin/run_sky_area.py
@@ -170,10 +170,7 @@ if __name__ == '__main__':
         skypost3d = sac.Clustered3DKDEPosterior(np.column_stack((data['ra'], data['dec'], data['dist'])))
 
         print('Producing distance map')
-        map3d = skypost3d.as_healpix(args.nside, nest=fits_nest)
-        mapsky = skypost.as_healpix(args.nside, nest=fits_nest)
-
-        hpmap = np.column_stack((mapsky, map3d)).T
+        hpmap = skypost3d.as_healpix(args.nside, nest=fits_nest)
         
     fits.write_sky_map(os.path.join(args.outdir, 'skymap.fits.gz'),
                        hpmap, creator=parser.get_prog_name(),


### PR DESCRIPTION
Looks correct now; checked for one event. See attached plot, which shows the lalinferenence_nest reconstructed volume for event 18951 from the [First Two Years paper](http://www.ligo.org/scientists/first2years/).

![lalinference_nest](https://cloud.githubusercontent.com/assets/728407/6879240/ede81d7c-d4c5-11e4-816d-c458a2bf4b83.png)

* The first commit switches back to using the standard FITS writer in LALSuite. The code is now safe to use both on LALSuite master and on the branch that supports the new distance layers.
* The second commit is just the math.