### PR TITLE
Use correct formulae for exact distance integrals

### DIFF
--- a/sky_area/sky_area_clustering.py
+++ b/sky_area/sky_area_clustering.py
@@ -642,7 +642,10 @@ class Clustered3DKDEPosterior(ClusteredSkyKDEPosterior):
             x = 0.5 * (1 + erf(mean / np.sqrt(2 * var)))
             y = np.sqrt(0.5*var/np.pi) * np.exp(-0.5 * np.square(mean) / var)
             mean2 = np.square(mean)
-            return (x, mean * x + y, (mean2 + var) * x + mean * y)
+            return (
+                (mean2 + var) * x + mean * y,
+                mean * (mean2 + 3 * var) * x + (mean2 + 2 * var) * y,
+                (mean2 * mean2 + 6 * mean2 * var + 3 * var * var) * x + mean * (mean2 + 5 * var) * y)
         
         npix = hp.nside2npix(nside)
 


### PR DESCRIPTION
The integrals should be with respect to r^2, r^3, and r^4. See below.

![distance_pp_new](https://cloud.githubusercontent.com/assets/728407/6941549/d6efed8e-d84e-11e4-8577-4023e4b77503.png)
