### PR TITLE
Remove stray leading space in interpreter line

### DIFF
--- a/bin/run_sky_area.py
+++ b/bin/run_sky_area.py
@@ -1,4 +1,4 @@
- #!/usr/bin/env python
+#!/usr/bin/env python
 from __future__ import print_function
 
 from optparse import OptionParser


### PR DESCRIPTION
This error, introduced in 2923998777188375771a9b560b8b7895d77107de, made the script un-runnable on certain systems (e.g., Mac OS X).