### PR TITLE
Do not create empty clusters

### DIFF
--- a/sky_area/sky_area_clustering.py
+++ b/sky_area/sky_area_clustering.py
@@ -356,15 +356,10 @@ class ClusteredSkyKDEPosterior(object):
         ndim = self.kde_pts.shape[1]
         for i in range(k):
             sel = (self.assign == i)
-            if np.sum(sel) <= ndim:
-                # If we have <= ndim points in a cluster, then the
-                # covariance is singular.  In this case, ignore these
-                # points.  If there are a significant number of points
-                # that land in such small clusters, then hopefully
-                # this clustering will be rejected by the BIC.
-                self._kdes.append(lambda x : 0.0)
-                self._weights.append(0.0)
-            else:
+            # If there are fewer points than degrees of freedom, then don't
+            # bother adding a KDE for that cluster; its covariance would be
+            # singular.
+            if np.sum(sel) > ndim:
                 self._kdes.append(gaussian_kde(self.kde_pts[sel,:].T))
                 self._weights.append(float(np.sum(sel)))
         self._weights = np.array(self.weights)


### PR DESCRIPTION
If the k-means algorithm generates clusters that contain fewer points than the number of degrees of freedom, then instead of creating empty clusters, omit those clusters.

This ensures that the clustered KDE data structure is picklable and eliminates a potential corner case that consumers of the clustered KDE would otherwise have to deal with.