### PR TITLE
Narrow scope of exception for LIB sky maps

### DIFF
--- a/bin/run_sky_area.py
+++ b/bin/run_sky_area.py
@@ -202,11 +202,12 @@ if __name__ == '__main__':
     else:
         print('Constructing 3D clustered posterior.')
         try:
-          skypost3d = sac.Clustered3DKDEPosterior(np.column_stack((data['ra'], data['dec'], data['dist'])))
-        except:
-          print("ERROR, cannot use skypost3d with LIB output. Exiting..\n")
-          import sys
-          sys.exit(1)
+            xyz = np.column_stack((data['ra'], data['dec'], data['dist']))
+        except ValueError:
+            print("ERROR, cannot use skypost3d with LIB output. Exiting..\n")
+            import sys
+            sys.exit(1)
+        skypost3d = sac.Clustered3DKDEPosterior(xyz)
 
         print('Producing distance map')
         hpmap = skypost3d.as_healpix(args.nside, nest=fits_nest)


### PR DESCRIPTION
It's really only necessary here to catch if the chain lacks the 'dist' column.