### PR TITLE
Ensure that best_means is always defined

### DIFF
--- a/sky_area/sky_area_clustering.py
+++ b/sky_area/sky_area_clustering.py
@@ -334,7 +334,7 @@ class ClusteredSkyKDEPosterior(object):
 
             print 'k = ', k, 'ntrials = ', ntrials, 'bic = ', bic
             
-            if bic > best_bic:
+            if bic >= best_bic:
                 best_means = self.means
                 best_assign = self.assign
                 best_bic = bic


### PR DESCRIPTION
Guarantee that best_means is defined by accepting any BIC value, even -inf. In my testing on 500 of the first2years events, the algorithm does always terminate.

Fixes #12.