### PR TITLE
Use distutils.dir_util.mkpath() for 'mkdir -p' behavior

### DIFF
--- a/bin/run_sky_area.py
+++ b/bin/run_sky_area.py
@@ -5,6 +5,7 @@ import matplotlib as mpl
 mpl.use('Agg')
 
 from optparse import OptionParser
+from distutils.dir_util import mkpath
 from glue.ligolw import ligolw
 from glue.ligolw import lsctables
 from glue.ligolw import table
@@ -141,10 +142,7 @@ if __name__ == '__main__':
         with open(args.loadpost, 'r') as inp:
             skypost = pickle.load(inp)
 
-    try:
-        os.makedirs(args.outdir)
-    except:
-        pass
+    mkpath(args.outdir)
 
     print('pickling ...')
     with open(os.path.join(args.outdir, 'skypost.obj'), 'w') as out:


### PR DESCRIPTION
This is part of the Python standard library, and is safer because it is more selective about what exceptions it catches.