### PR TITLE
Release 0.2.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+skyarea (0.2.1-1) UNRELEASED; urgency=medium
+
+  * Re-release with packaging distributed in upstream source.
+
+ -- Leo Singer <leo.singer@ligo.org>  Tue, 18 Oct 2016 20:17:38 -0500
+
 skyarea (0.2-1) unstable; urgency=medium
 
   * Move Debian packaging version control to git.ligo.org.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='skyarea',
     packages=['sky_area'],
     scripts=['bin/make_search_map', 'bin/process_areas', 'bin/run_sky_area'],
-    version='0.2',
+    version='0.2.1',
     description='Compute credible regions on the sky from RA-DEC MCMC samples',
     author='Will M. Farr',
     author_email='will.farr@ligo.org',

--- a/skyarea.spec
+++ b/skyarea.spec
@@ -1,6 +1,6 @@
 Summary: Compute credible regions on the sky from RA-DEC MCMC samples
 Name: skyarea
-Version: 0.2
+Version: 0.2.1
 Release: 1%{?dist}
 Source: https://github.com/farr/skyarea/archive/v%{version}/%{name}-%{version}.tar.gz
 License: MIT
@@ -32,6 +32,10 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root)
 
 %changelog
+* Tue Oct 18 2016 Leo Singer <leo.singer@ligo.org> 0.2.1-1
+
+- Re-release with packaging distributed in upstream tarball
+
 * Tue Oct 18 2016 Leo Singer <leo.singer@ligo.org> 0.2-1
 
 - ER10 release


### PR DESCRIPTION
I screwed up the SL7 packaging, and Adam requested a new version. See https://bugs.ligo.org/redmine/issues/4759.

I am providing this patch to show the three places where the version has to be changed: `setup.py`, `debian/changelog`, and `skyarea.spec`.