### PR TITLE
Find optimal k using a brute-force search

### DIFF
--- a/sky_area/sky_area_clustering.py
+++ b/sky_area/sky_area_clustering.py
@@ -255,7 +255,33 @@ class ClusteredSkyKDEPosterior(object):
         """
         return self._greedy_posteriors
 
-    def _set_up_optimal_k(self):
+    def _set_up_optimal_k(self, method='brute'):
+        {
+            'brute': self._set_up_optimal_k_brute,
+            'bracket': self._set_up_optimal_k_bracket
+        }[method]()
+
+    def _set_up_optimal_k_brute(self):
+        self._set_up_kmeans(1)
+        ks = [1]
+        bics = [self._bic()]
+        assigns = [self.assign]
+        means = [self.means]
+        for k in range(2, 41):
+            self._set_up_optimal_kmeans(k, self.ntrials)
+            ks.append(k)
+            bics.append(self._bic())
+            assigns.append(self.assign)
+            means.append(self.means)
+        i = np.argmax(bics)
+        bic = bics[i]
+        k = ks[i]
+        assign = assigns[i]
+        means = means[i]
+        print('Found best k, BIC: ', k, bic)
+        self._set_up_kmeans(k, means, assign)
+
+    def _set_up_optimal_k_bracket(self):
         self._set_up_kmeans(1)
         low_bic = self._bic()
         low_assign = self.assign

--- a/sky_area/sky_area_clustering.py
+++ b/sky_area/sky_area_clustering.py
@@ -328,15 +328,21 @@ class ClusteredSkyKDEPosterior(object):
         self._set_up_kmeans(mid_k, mid_means, mid_assign)
 
     def _set_up_optimal_kmeans(self, k, ntrials):
-        best_bic = np.NINF
+        self._set_up_kmeans(k)
 
-        for i in range(ntrials):
+        best_means = self.means
+        best_assign = self.assign
+        best_bic = self._bic()
+
+        print('k = ', k, 'ntrials = ', ntrials, 'bic = ', best_bic)
+
+        for i in range(ntrials - 1):
             self._set_up_kmeans(k)
             bic = self._bic()
 
             print('k = ', k, 'ntrials = ', ntrials, 'bic = ', bic)
 
-            if bic >= best_bic:
+            if bic > best_bic:
                 best_means = self.means
                 best_assign = self.assign
                 best_bic = bic


### PR DESCRIPTION
For 3D Cartesian representation of 2-detector events, the older bracketing algorithm was getting stuck on a local optimum of k=2 clusters that was not the global optimum.

This is an alternative to #56.
