### PR TITLE
Don't create empty FITS header cards

### DIFF
--- a/bin/run_sky_area
+++ b/bin/run_sky_area
@@ -244,26 +244,24 @@ if __name__ == '__main__':
 
     hpmap = skypost.as_healpix(
         args.nside, nest=fits_nest, fast=not(args.slowsmoothskymaps))
+
+    meta = {'creator': parser.get_prog_name()}
+    if args.objid is not None:
+        meta['objid'] = args.objid
     if args.enable_distance_map:
-        distmean = np.mean(dist)
-        diststd = np.std(dist)
-    else:
-        distmean = None
-        diststd = None
+        meta['distmean'] = np.mean(dist)
+        meta['diststd'] = np.std(dist)
 
     names = data.dtype.names
     if 'time' in names:
-        gps_time = data['time'].mean()
+        meta['gps_time'] = data['time'].mean()
     elif 'time_mean' in names:
-        gps_time = data['time_mean'].mean()
+        meta['gps_time'] = data['time_mean'].mean()
     elif 'time_maxl' in names:
-        gps_time = data['time_maxl'].mean()
+        meta['gps_time'] = data['time_maxl'].mean()
     else:
         parser.error(
             "Cannot find time, time_mean, or time maxl variable in posterior.")
 
     fits.write_sky_map(os.path.join(args.outdir, args.fitsoutname),
-                       hpmap, creator=parser.get_prog_name(),
-                       objid=args.objid, gps_time=gps_time,
-                       distmean=distmean, diststd=diststd,
-                       nest=fits_nest)
+                       hpmap, nest=fits_nest, **meta)


### PR DESCRIPTION
Don't add `DISTMEAN` or `DISTSTD` cards to the FITS header if we are not generating a 3D sky map. Don't add the OBJECT card if the user did not pass a value for the `--objid` keyword argument.

If these are passed as `None` to `fits.write_sky_map`, then ugly empty header cards are created. If we don't want to populate those header cards, then we shouldn't pass them to begin with.

In full disclosure, this is due to an upstream change in how `fits.write_sky_map` treats its keyword arguments.