### PR TITLE
Output sky maps in NESTED, not UNIQ, ordering

### DIFF
--- a/bin/run_sky_area
+++ b/bin/run_sky_area
@@ -41,6 +41,7 @@ if __name__ == '__main__':
     from distutils.dir_util import mkpath
     from lalinference.io import fits
     from lalinference.io import hdf5
+    from lalinference.bayestar.sky_map import rasterize
     from astropy.table import Table
     from astropy.time import Time
     from astropy.utils.misc import NumpyRNGContext
@@ -98,7 +99,7 @@ if __name__ == '__main__':
         skypost.multiprocess = args.j
 
     print('making skymap ...')
-    hpmap = skypost.as_healpix()
+    hpmap = rasterize(skypost.as_healpix())
     hpmap.meta['creator'] = parser.get_prog_name()
     hpmap.meta['origin'] = 'LIGO/Virgo'
     hpmap.meta['gps_creation_time'] = Time.now().gps


### PR DESCRIPTION
In commit 61806b51464c796d2f357a363397f4c2f6e55175, we switched to generating multi-order sky maps in the `UNIQ` ordering to simplify and speed up the process of generating the distance layers. However, we need to actually _write_ flat, single-resolution, `NESTED`-ordering sky maps because that is what most HEALPix/FITS-reading programs and libraries expect.