### PR TITLE
Make compatible with Python 3

### DIFF
--- a/bin/run_sky_area
+++ b/bin/run_sky_area
@@ -95,10 +95,10 @@ if __name__ == '__main__':
         skypost = cls(pts, trials=args.trials, multiprocess=args.j)
 
         print('pickling ...')
-        with open(os.path.join(args.outdir, 'skypost.obj'), 'w') as out:
+        with open(os.path.join(args.outdir, 'skypost.obj'), 'wb') as out:
             pickle.dump(skypost, out)
     else:
-        with open(args.loadpost, 'r') as inp:
+        with open(args.loadpost, 'rb') as inp:
             skypost = pickle.load(inp)
         skypost.multiprocess = args.j
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
                  'Intended Audience :: Science/Research',
                  'License :: OSI Approved :: MIT License',
                  'Programming Language :: Python :: 2.7',
+                 'Programming Language :: Python :: 3.6',
                  'Topic :: Scientific/Engineering :: Astronomy',
                  'Topic :: Scientific/Engineering :: Visualization']
 )

--- a/sky_area/sky_area_clustering.py
+++ b/sky_area/sky_area_clustering.py
@@ -237,7 +237,7 @@ class SkyKDE(ClusteredKDE):
         for iround in range(rounds - 1):
             print('adaptive refinement round {} of {} ...'.format(
                   iround + 1, rounds - 1))
-            cells = sorted(cells, key=lambda (p, n, i): p / n**2)
+            cells = sorted(cells, key=lambda p_n_i: p_n_i[0] / p_n_i[1]**2)
             new_nside, new_ipix = np.transpose([
                 (nside * 2, ipix * 4 + i)
                 for _, nside, ipix in cells[-nrefine:] for i in range(4)])

--- a/sky_area/sky_area_clustering.py
+++ b/sky_area/sky_area_clustering.py
@@ -10,7 +10,6 @@ import numpy.linalg as nl
 from scipy.stats import gaussian_kde
 from lalinference.bayestar import distance, moc
 from functools import partial
-from six.moves import copyreg
 
 __all__ = ('Clustered2DSkyKDE', 'Clustered3DSkyKDE', 'Clustered2Plus1DSkyKDE')
 
@@ -267,13 +266,12 @@ class SkyKDE(ClusteredKDE):
         return Table([uniq, post], names=['UNIQ', 'PROBDENSITY'])
 
 
-class _Clustered2DSkyKDEMeta(type):
-    """This metaclass is required to make classes picklable because
-    our __new__ method dynamically creates a class that is not literally
-    present in the module."""
-def _Clustered2DSkyKDEMeta_pickle(cls):
-    return type, (cls.__name__, cls.__bases__, {'frame': cls.frame})
-copyreg.pickle(_Clustered2DSkyKDEMeta, _Clustered2DSkyKDEMeta_pickle)
+# FIXME: in Python 3, make this a class method.
+# Python 2 is picky about pickling bound class methods.
+def _factory(cls, frame):
+    name = '{:s}_{:x}'.format(cls.__name__, id(frame))
+    new_cls = type(name, (cls,), {'frame': frame})
+    return super(Clustered2DSkyKDE, cls).__new__(new_cls)
 
 
 class Clustered2DSkyKDE(SkyKDE):
@@ -304,7 +302,6 @@ class Clustered2DSkyKDE(SkyKDE):
 
     """
 
-    __metaclass__ = _Clustered2DSkyKDEMeta
     frame = None
 
     @classmethod
@@ -314,16 +311,10 @@ class Clustered2DSkyKDE(SkyKDE):
 
     def __new__(cls, pts, *args, **kwargs):
         frame = EigenFrame.for_coords(SkyCoord(*pts.T, unit='rad'))
-        name = '{:s}_{:x}'.format(cls.__name__, id(frame))
-        new_cls = type(name, (cls,), {'frame': frame})
-        return super(Clustered2DSkyKDE, cls).__new__(new_cls)
+        return _factory(cls, frame)
 
-    @classmethod
-    def __reduce__(cls):
-        """This method is required to make instances picklable because
-        our __new__ method dynamically creates a class that is not literally
-        present in the module."""
-        return type, (cls.__name__, cls.__bases__, {'frame': cls.frame})
+    def __reduce__(self):
+        return _factory, (Clustered2DSkyKDE, self.frame,), self.__dict__
 
     def eval_kdes(self, pts):
         base = super(Clustered2DSkyKDE, self).eval_kdes

--- a/sky_area/sky_area_clustering.py
+++ b/sky_area/sky_area_clustering.py
@@ -135,7 +135,8 @@ class ClusteredKDE(object):
             seed = np.random.randint(0, 2**32 - max_k * trials)
             func = partial(_cluster, type(self), pts, trials, seed=seed)
             self.bic, self.k, self.kdes = max(
-                self._map(func, range(trials, (max_k + 1) * trials)))
+                self._map(func, range(trials, (max_k + 1) * trials)),
+                key=lambda items: items[:2])
         else:
             # Build KDEs for each cluster, skipping degenerate clusters
             self.kdes = []

--- a/sky_area/sky_area_clustering.py
+++ b/sky_area/sky_area_clustering.py
@@ -316,8 +316,7 @@ class Clustered2DSkyKDE(SkyKDE):
         frame = EigenFrame.for_coords(SkyCoord(*pts.T, unit='rad'))
         name = '{:s}_{:x}'.format(cls.__name__, id(frame))
         new_cls = type(name, (cls,), {'frame': frame})
-        return super(Clustered2DSkyKDE, cls).__new__(
-            new_cls, pts, *args, **kwargs)
+        return super(Clustered2DSkyKDE, cls).__new__(new_cls)
 
     @classmethod
     def __reduce__(cls):


### PR DESCRIPTION
These patches make skyarea compatible with both Python 2 and Python 3. They fix a number of small issues, mostly related to pickling/unpickling.